### PR TITLE
Add new setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ All your models should now be registered in the admin.
     'admin.LogEntry',]'`
   - `ADMIN_AUTOREGISTER_EXCLUDE_INLINES` is a boolean that determines whether or not to exclude models that are already registered as inlines of other models.
     - Defaults to `True`
+  - `ADMIN_AUTOREGISTER_UNREGISTER_LIST` is a list of models to unregister from admin. This is usefull when you want to unregister models from other apps such as Celery, Oauth which are registered by default.
+    - Defaults to `[]` 
 
 Mixins
 ------

--- a/admin_autoregister/admin.py
+++ b/admin_autoregister/admin.py
@@ -1,7 +1,6 @@
 from django.apps import apps
 from django.contrib import admin
 from django.conf import settings
-
 from admin_autoregister.mixins import ListDisplayAdminMixin, ListFilterAdminMixin, AutocompleteFieldsAdminMixin, \
     SelectRelatedFieldsAdminMixin, DateHierarchyAdminMixin
 
@@ -12,6 +11,8 @@ ADMIN_AUTOREGISTER_EXCLUDE = [model.lower() for model in getattr(settings, 'ADMI
     'admin.LogEntry',
 ])]
 ADMIN_AUTOREGISTER_EXCLUDE_INLINES = getattr(settings, 'ADMIN_AUTOREGISTER_EXCLUDE_INLINES', True)
+
+ADMIN_AUTOREGISTER_UNREGISTER_LIST = getattr(settings, 'ADMIN_AUTOREGISTER_UNREGISTER_LIST', [])
 
 inline_models = [item.model for sublist in [v.inlines for k, v in admin.site._registry.items() if len(v.inlines) > 0]
                  for item
@@ -29,4 +30,15 @@ for model in models:
     try:
         admin.site.register(model, admin_class)
     except admin.sites.AlreadyRegistered:
+        pass
+
+unregister_models = [model for model in apps.get_models() 
+                    if '{app_label}.{model_name}'.format(app_label=model._meta.app_label, 
+                                                model_name=model._meta.model_name) in ADMIN_AUTOREGISTER_UNREGISTER_LIST]
+
+for model in unregister_models:
+    print(model)
+    try:
+        admin.site.unregister(model)
+    except admin.sites.NotRegistered:
         pass

--- a/admin_autoregister/admin.py
+++ b/admin_autoregister/admin.py
@@ -37,7 +37,6 @@ unregister_models = [model for model in apps.get_models()
                                                 model_name=model._meta.model_name) in ADMIN_AUTOREGISTER_UNREGISTER_LIST]
 
 for model in unregister_models:
-    print(model)
     try:
         admin.site.unregister(model)
     except admin.sites.NotRegistered:


### PR DESCRIPTION
Adds a new setting `ADMIN_AUTOREGISTER_UNREGISTER_LIST` in which we can specify django models which we want to unregister from django admin. This is usefull for unregistering models from apps like Celery, Oauth2 which come registered by default, otherwise we would need to manually unregister them in `admin.py`